### PR TITLE
Update action button visibility for order statuses

### DIFF
--- a/client/src/pages/SalesRep/orders/OrderDetails.jsx
+++ b/client/src/pages/SalesRep/orders/OrderDetails.jsx
@@ -808,7 +808,7 @@ const OrderDetails = ({ item, changeOpen = () => {} }) => {
 
         {/* Action Buttons: Accept, Reject, Create Quotation */}
         <div className="mt-8 flex flex-row gap-4 justify-end">
-          {orderStatus === "approved" ? (
+          {orderStatus === "approved" || orderStatus === "inprogress" || orderStatus === "completed" ? (
             <button
               className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-6 rounded-lg transition"
               onClick={() => {


### PR DESCRIPTION
Action buttons are now shown when orderStatus is 'approved', 'inprogress', or 'completed', instead of only 'approved'. This allows users to access actions for more order states.