### PR TITLE
Integrate API data for summary report pages

### DIFF
--- a/backend/api-gateway/server.js
+++ b/backend/api-gateway/server.js
@@ -29,12 +29,17 @@ app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 // Rate limiting
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // limit each IP to 100 requests per windowMs
+  max: 1000, // limit each IP to 1000 requests per windowMs
   message: 'Too many requests from this IP, please try again later.',
   standardHeaders: true,
   legacyHeaders: false,
 });
-app.use(limiter);
+
+
+if (process.env.NODE_ENV === 'production') {
+  app.use(limiter);
+}
+
 
 // JWT Authentication middleware
 const authenticateToken = (req, res, next) => {

--- a/client/src/pages/Administrator/reports/DailySummary.jsx
+++ b/client/src/pages/Administrator/reports/DailySummary.jsx
@@ -2,136 +2,134 @@ import {useEffect, useState} from "react";
 import {FaSpinner} from "react-icons/fa";
 import { NotebookPen, Download, Calendar, Filter, TrendingUp, FileText, Users, Package } from "lucide-react";
 
-// Mock data for testing
-const mockDailySummaryData = [
-  {
-    quotation_id: "QUO001",
-    quotation_date: "2025-08-13", // Today's date
-    customer_id: "CUST001",
-    sales_rep_id: "EMP001",
-    no_items: 5,
-    net_total: 15750.00,
-    status: "Completed"
-  },
-  {
-    quotation_id: "QUO002",
-    quotation_date: "2025-08-13", // Today's date
-    customer_id: "CUST002",
-    sales_rep_id: "EMP002",
-    no_items: 3,
-    net_total: 8900.50,
-    status: "Pending"
-  },
-  {
-    quotation_id: "QUO003",
-    quotation_date: "2025-08-13", // Today's date
-    customer_id: "CUST003",
-    sales_rep_id: "EMP001",
-    no_items: 7,
-    net_total: 22300.75,
-    status: "Processing"
-  },
-  {
-    quotation_id: "QUO004",
-    quotation_date: "2025-08-13", // Today's date
-    customer_id: "CUST004",
-    sales_rep_id: "EMP003",
-    no_items: 2,
-    net_total: 5600.00,
-    status: "Completed"
-  },
-  {
-    quotation_id: "QUO005",
-    quotation_date: "2025-08-12",
-    customer_id: "CUST005",
-    sales_rep_id: "EMP002",
-    no_items: 4,
-    net_total: 12450.25,
-    status: "Cancelled"
-  },
-  {
-    quotation_id: "QUO006",
-    quotation_date: "2025-08-12",
-    customer_id: "CUST006",
-    sales_rep_id: "EMP001",
-    no_items: 6,
-    net_total: 18900.00,
-    status: "Pending"
-  },
-  {
-    quotation_id: "QUO007",
-    quotation_date: "2025-08-11",
-    customer_id: "CUST007",
-    sales_rep_id: "EMP003",
-    no_items: 8,
-    net_total: 31200.50,
-    status: "Completed"
-  },
-  {
-    quotation_id: "QUO008",
-    quotation_date: "2025-08-11",
-    customer_id: "CUST008",
-    sales_rep_id: "EMP002",
-    no_items: 1,
-    net_total: 2750.00,
-    status: "Processing"
-  }
-];
-
 const DailySummary = () => {
   const [isLoading, setIsLoading] = useState(false);
-  const [dailySummaryData, setDailySummaryData] = useState(mockDailySummaryData);
+  const [dailySummaryData, setDailySummaryData] = useState([]);
+  const [summaryStats, setSummaryStats] = useState({
+    total_quotations: 0,
+    total_value: 0,
+    total_items: 0,
+    unique_customers: 0
+  });
+  const [statusOptions, setStatusOptions] = useState(["All"]);
   const [statusFilter, setStatusFilter] = useState("All");
 
   const today = new Date().toISOString().split("T")[0];
   const [reportDate, setReportDate] = useState(today);
 
+  // API call functions
+  const fetchDailySummary = async (date, status) => {
+    const token = localStorage.getItem('token'); // Adjust based on your auth implementation
+    const statusParam = status === "All" ? "" : `&status=${status}`; // Pass empty string for "All"
+    const response = await fetch(`http://localhost:3000/api/reports/daily-summary?date=${date}${statusParam}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}` 
+      },
+      method: 'GET'
+    });
+    const result = await response.json();
+    return result;
+  };
+
+  const fetchDailySummaryStats = async (date) => {
+    const token = localStorage.getItem('token'); // Adjust based on your auth implementation
+    const response = await fetch(`http://localhost:3000/api/reports/daily-summary-stats?date=${date}`,{
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}` 
+      },
+      method: 'GET'
+    });
+    const result = await response.json();
+    return result;
+  };
+
+  const fetchDailyStatusOptions = async (date) => {
+    const token = localStorage.getItem('token'); // Adjust based on your auth implementation
+    const response = await fetch(`http://localhost:3000/api/reports/daily-status-options?date=${date}`,{
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}` 
+      },
+      method: 'GET'
+    });
+    const result = await response.json();
+    return result;
+  };
+
   useEffect(() => {
-    (async () => {
+    const loadDailyData = async () => {
       try {
         setIsLoading(true);
-        // Use mock data for now - comment out the API call
-        // const result = await dailySummary(reportDate);
-        // console.log("result", result);
-        // if (result.success) {
-        //   setDailySummaryData(result.data.data);
-        // } else {
-        //   console.error("No data found");
-        // }
         
-        // Filter mock data by selected date
-        const filteredMockData = mockDailySummaryData.filter(item => 
-          item.quotation_date === reportDate
-        );
-        setDailySummaryData(filteredMockData);
-        
+        // Fetch all data concurrently
+        const [summaryResult, statsResult, statusResult] = await Promise.all([
+          fetchDailySummary(reportDate, statusFilter), // Pass statusFilter here
+          fetchDailySummaryStats(reportDate),
+          fetchDailyStatusOptions(reportDate)
+        ]);
+
+        // Set daily summary data
+        if (summaryResult.success) {
+          setDailySummaryData(summaryResult.data);
+        } else {
+          console.error("Failed to fetch daily summary:", summaryResult);
+          setDailySummaryData([]);
+        }
+
+        // Set summary stats
+        if (statsResult.success) {
+          setSummaryStats({
+            total_quotations: parseInt(statsResult.data.total_quotations) || 0,
+            total_value: parseFloat(statsResult.data.total_value) || 0,
+            total_items: parseInt(statsResult.data.total_items) || 0,
+            unique_customers: parseInt(statsResult.data.unique_customers) || 0
+          });
+        } else {
+          console.error("Failed to fetch summary stats:", statsResult);
+          setSummaryStats({
+            total_quotations: 0,
+            total_value: 0,
+            total_items: 0,
+            unique_customers: 0
+          });
+        }
+
+        // Set status options
+        if (statusResult.success) {
+          setStatusOptions(["All", ...statusResult.data]);
+        } else {
+          console.error("Failed to fetch status options:", statusResult);
+          setStatusOptions(["All"]);
+        }
+
       } catch (error) {
-        console.error(error);
-        // Fallback to mock data on error
-        setDailySummaryData(mockDailySummaryData.filter(item => 
-          item.quotation_date === reportDate
-        ));
+        console.error("Error loading daily data:", error);
+        // Reset to empty state on error
+        setDailySummaryData([]);
+        setSummaryStats({
+          total_quotations: 0,
+          total_value: 0,
+          total_items: 0,
+          unique_customers: 0
+        });
+        setStatusOptions(["All"]);
       } finally {
         setIsLoading(false);
       }
-    }) ();
-  }, [reportDate]);
+    };
 
-  const statusOptions = ["All", ...new Set(dailySummaryData?.map((data) => data.status) || [])];
+    loadDailyData();
+  }, [reportDate, statusFilter]); // Add statusFilter as a dependency
 
+  // Filter data based on status
   const filteredData = (dailySummaryData || []).filter((data) => {
     return statusFilter === "All" || data.status === statusFilter;
   });
 
-  // Calculate summary stats
-  const totalQuotations = filteredData.length;
-  const totalValue = filteredData.reduce((sum, item) => sum + (typeof item.net_total === 'number' ? item.net_total : 0), 0);
-  const totalItems = filteredData.reduce((sum, item) => sum + item.no_items, 0);
-  const uniqueCustomers = new Set(filteredData.map(item => item.customer_id)).size;
-
   const handleExportSummary = () => {
     if (!dailySummaryData || dailySummaryData.length === 0) {
-      // Use console.log instead of alert to avoid popup
       console.log("No data to export");
       return;
     }
@@ -139,51 +137,67 @@ const DailySummary = () => {
     exportToCSV(dailySummaryData, "daily-summary.csv");
   }
 
-  // export to csv file
+  // Export to CSV file
   function exportToCSV(arr, filename = 'data.csv') {
     if (!arr || arr.length === 0) {
       console.error("No data to export");
       return;
     }
     
-    // convert the array of objects to CSV format
-    const keys = Object.keys(arr[0]); // extract keys as the CSV header (column names)
+    // Convert the array of objects to CSV format
+    const keys = Object.keys(arr[0]);
     const csvRows = [];
 
-    // add the header row
+    // Add the header row
     csvRows.push(keys.join(','));
 
     // Add data rows
     for (const row of arr) {
-      const values = keys.map(key => row[key]);
+      const values = keys.map(key => {
+        const value = row[key];
+        // Handle values that might contain commas by wrapping in quotes
+        if (typeof value === 'string' && value.includes(',')) {
+          return `"${value}"`;
+        }
+        return value;
+      });
       csvRows.push(values.join(','));
     }
 
-    // create the CSV content (combine all rows into a single string)
+    // Create the CSV content
     const csvData = csvRows.join('\n');
 
-    // create a Blob from the CSV data and trigger a download
+    // Create a Blob from the CSV data and trigger a download
     const blob = new Blob([csvData], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);
 
-    // create an anchor element and simulate a click to download the file
+    // Create an anchor element and simulate a click to download the file
     const link = document.createElement('a');
     link.href = url;
     link.download = filename;
     link.click();
 
-    // clean up the URL object
+    // Clean up the URL object
     URL.revokeObjectURL(url);
   }
 
   const getStatusColor = (status) => {
     const colors = {
-      'Completed': 'from-emerald-500 to-green-600 text-white shadow-green-200',
-      'Pending': 'from-amber-400 to-yellow-500 text-white shadow-yellow-200',
-      'Processing': 'from-blue-500 to-indigo-600 text-white shadow-blue-200',
-      'Cancelled': 'from-red-500 to-rose-600 text-white shadow-red-200'
+      'completed': 'from-emerald-500 to-green-600 text-white shadow-green-200',
+      'pending': 'from-amber-400 to-yellow-500 text-white shadow-yellow-200',
+      'processing': 'from-blue-500 to-indigo-600 text-white shadow-blue-200',
+      'cancelled': 'from-red-500 to-rose-600 text-white shadow-red-200'
     };
-    return colors[status] || 'from-gray-400 to-gray-500 text-white shadow-gray-200';
+    return colors[status?.toLowerCase()] || 'from-gray-400 to-gray-500 text-white shadow-gray-200';
+  };
+
+  const formatCurrency = (amount) => {
+    const numAmount = typeof amount === 'string' ? parseFloat(amount) : amount;
+    return numAmount.toLocaleString('en-IN', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+  };
+
+  const formatDate = (dateString) => {
+    return new Date(dateString).toLocaleDateString('en-GB');
   };
 
   return (
@@ -220,7 +234,7 @@ const DailySummary = () => {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-blue-100 text-sm">Total Quotations</p>
-              <p className="text-2xl font-bold">{totalQuotations}</p>
+              <p className="text-2xl font-bold">{summaryStats.total_quotations}</p>
             </div>
             <FileText className="w-8 h-8 text-blue-200" />
           </div>
@@ -230,7 +244,7 @@ const DailySummary = () => {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-emerald-100 text-sm">Total Value</p>
-              <p className="text-2xl font-bold">Rs {totalValue.toLocaleString('en-IN', {minimumFractionDigits: 2, maximumFractionDigits: 2})}</p>
+              <p className="text-2xl font-bold">Rs {formatCurrency(summaryStats.total_value)}</p>
             </div>
             <TrendingUp className="w-8 h-8 text-emerald-200" />
           </div>
@@ -240,7 +254,7 @@ const DailySummary = () => {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-purple-100 text-sm">Total Items</p>
-              <p className="text-2xl font-bold">{totalItems}</p>
+              <p className="text-2xl font-bold">{summaryStats.total_items}</p>
             </div>
             <Package className="w-8 h-8 text-purple-200" />
           </div>
@@ -250,7 +264,7 @@ const DailySummary = () => {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-orange-100 text-sm">Unique Customers</p>
-              <p className="text-2xl font-bold">{uniqueCustomers}</p>
+              <p className="text-2xl font-bold">{summaryStats.unique_customers}</p>
             </div>
             <Users className="w-8 h-8 text-orange-200" />
           </div>
@@ -268,7 +282,7 @@ const DailySummary = () => {
           >
             {statusOptions.map((status) => (
               <option key={status} value={status}>
-                {status} Status
+                {status === "All" ? "All Status" : `${status.charAt(0).toUpperCase() + status.slice(1)} Status`}
               </option>
             ))}
           </select>
@@ -293,8 +307,8 @@ const DailySummary = () => {
               <tr>
                 <th className="py-4 px-6 text-left font-semibold">Quotation ID</th>
                 <th className="py-4 px-6 text-left font-semibold">Date</th>
-                <th className="py-4 px-6 text-left font-semibold">Customer ID</th>
-                <th className="py-4 px-6 text-left font-semibold">Sales Rep ID</th>
+                <th className="py-4 px-6 text-left font-semibold">Customer</th>
+                <th className="py-4 px-6 text-left font-semibold">Sales Rep</th>
                 <th className="py-4 px-6 text-center font-semibold">No. Items</th>
                 <th className="py-4 px-6 text-right font-semibold">Order Total</th>
                 <th className="py-4 px-6 text-center font-semibold">Status</th>
@@ -311,7 +325,7 @@ const DailySummary = () => {
                   </td>
                 </tr>
               ) : (
-                (dailySummaryData || []).length === 0 ? (
+                filteredData.length === 0 ? (
                   <tr>
                     <td colSpan={7} className="py-12 text-center">
                       <div className="flex flex-col items-center gap-4">
@@ -320,7 +334,7 @@ const DailySummary = () => {
                         </div>
                         <div>
                           <p className="text-lg font-semibold text-gray-700">No records found</p>
-                          <p className="text-gray-500">No quotations available for the selected date.</p>
+                          <p className="text-gray-500">No quotations available for the selected date and status.</p>
                         </div>
                       </div>
                     </td>
@@ -334,17 +348,23 @@ const DailySummary = () => {
                         </span>
                       </td>
                       <td className="py-4 px-6 text-gray-700 font-medium">
-                        {new Date(data.quotation_date).toLocaleDateString()}
+                        {formatDate(data.quotation_date)}
                       </td>
                       <td className="py-4 px-6">
-                        <span className="font-mono text-sm text-gray-600 bg-gray-100 px-2 py-1 rounded">
-                          {data.customer_id}
-                        </span>
+                        <div className="flex flex-col">
+                          <span className="font-medium text-gray-800">{data.customer_name}</span>
+                          <span className="font-mono text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded mt-1 inline-block">
+                            {data.customer_id}
+                          </span>
+                        </div>
                       </td>
                       <td className="py-4 px-6">
-                        <span className="font-mono text-sm text-gray-600 bg-gray-100 px-2 py-1 rounded">
-                          {data.sales_rep_id}
-                        </span>
+                        <div className="flex flex-col">
+                          <span className="font-medium text-gray-800">{data.sales_rep_name}</span>
+                          <span className="font-mono text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded mt-1 inline-block">
+                            {data.sales_rep_id}
+                          </span>
+                        </div>
                       </td>
                       <td className="py-4 px-6 text-center">
                         <span className="inline-flex items-center justify-center w-8 h-8 bg-blue-100 text-blue-800 rounded-full font-bold text-sm">
@@ -353,11 +373,11 @@ const DailySummary = () => {
                       </td>
                       <td className="py-4 px-6 text-right">
                         <span className="font-bold text-lg text-green-700">
-                          Rs {typeof data.net_total === 'number' ? data.net_total.toLocaleString('en-IN', {minimumFractionDigits: 2, maximumFractionDigits: 2}) : data.net_total}
+                          Rs {formatCurrency(data.net_total)}
                         </span>
                       </td>
                       <td className="py-4 px-6 text-center">
-                        <span className={`inline-block px-3 py-1 rounded-full text-xs font-bold bg-gradient-to-r shadow-md ${getStatusColor(data.status)}`}>
+                        <span className={`inline-block px-3 py-1 rounded-full text-xs font-bold bg-gradient-to-r shadow-md ${getStatusColor(data.status)} capitalize`}>
                           {data.status}
                         </span>
                       </td>


### PR DESCRIPTION
Replaced mock data with API calls in DailySummary, WeeklySummary, and YearlySummary report pages. Added concurrent fetching of summary stats, status options, and breakdowns. Updated UI to use API-driven data, improved CSV export, and enhanced status/color formatting. Rate limiting in server.js is now only enabled in production and increased to 1000 requests per window.